### PR TITLE
Update go.mod to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-connect-plugin-example
 
-go 1.22.3
+go 1.23.1
 
 require (
 	github.com/redpanda-data/benthos/v4 v4.30.0


### PR DESCRIPTION
Updates project as it requires 1.23.0

```
0.170 go: go.mod requires go >= 1.23.0 (running go 1.22.7; GOTOOLCHAIN=local)
```